### PR TITLE
fix reset-password email URL to point to frontend instead of admin panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ HOST=0.0.0.0
 PORT=1337
 APP_KEYS=your-app-key-1,your-app-key-2,your-app-key-3
 # PUBLIC_URL=https://hubcommunity-manager.8020digital.com.br
+FRONTEND_URL=https://hubcommunity.io
 
 # Database Configuration
 DATABASE_CLIENT=sqlite

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,12 +24,12 @@ export default {
     });
 
     const settings = await pluginStore.get({ key: "email" });
-    const publicUrl =
-      process.env.PUBLIC_URL || "https://manager.hubcommunity.io";
+    const frontendUrl =
+      process.env.FRONTEND_URL || "https://hubcommunity.io";
 
     if (settings && settings.reset_password) {
       // 1. Force update the response_url
-      const resetPasswordUrl = `${publicUrl}/admin/auth/reset-password`;
+      const resetPasswordUrl = `${frontendUrl}/reset-password`;
       settings.reset_password.options.response_url = resetPasswordUrl;
 
       // 2. Hardcode the URL in the message to be 100% sure it's not empty


### PR DESCRIPTION
The reset email was linking to the Strapi admin panel (/admin/auth/reset-password), which uses a different auth system (admin_users) than the users-permissions plugin (up_users), causing 400 errors. Now points to FRONTEND_URL/reset-password.

Fixes #2 