### PR TITLE
feat: implement voting system infrastructure and aggregation API

### DIFF
--- a/src/api/vote/content-types/vote/lifecycles.ts
+++ b/src/api/vote/content-types/vote/lifecycles.ts
@@ -1,0 +1,61 @@
+import { errors } from '@strapi/utils';
+const { ApplicationError } = errors;
+
+export default {
+  async beforeCreate(event) {
+    const { data } = event.params;
+    
+    // Extract fingerprint, ip_address, and voting_session
+    const fingerprint = data.fingerprint;
+    const ip_address = data.ip_address;
+    
+    // In Strapi v4+, relations might come as a single ID or an object/array depending on how it's sent.
+    // E.g., data.voting_session = 1, or data.voting_session = { connect: [{ id: 1 }] }
+    // In Strapi v5, relations often use documentId: data.voting_session = { connect: [{ documentId: 'abc' }] }
+    let sessionId;
+    if (typeof data.voting_session === 'number' || typeof data.voting_session === 'string') {
+      sessionId = data.voting_session;
+    } else if (data.voting_session?.connect?.length > 0) {
+      sessionId = data.voting_session.connect[0].documentId || data.voting_session.connect[0].id;
+    } else if (data.voting_session?.set?.length > 0) {
+      sessionId = data.voting_session.set[0].documentId || data.voting_session.set[0].id;
+    }
+
+    if (!sessionId) {
+      console.log('--- ERROR: Session extraction failed ---');
+      console.log('Received voting_session:', JSON.stringify(data.voting_session, null, 2));
+      throw new ApplicationError('Voting session is required');
+    }
+
+    if (!fingerprint) {
+      throw new ApplicationError('Fingerprint is required to vote');
+    }
+
+    // Check if the voting_session is open
+    const session = await strapi.documents('api::voting-session.voting-session').findOne({ documentId: sessionId });
+    // Note: in Strapi 5, documentId is typically used instead of id for relations when querying `strapi.documents`
+    // Wait, the client usually sends the documentId as the relation. So sessionId will be a documentId.
+    
+    if (!session) {
+      // Let's fallback to finding by id if it's not documentId (in case of old usage with DB queries)
+      const sessionById = await strapi.db.query('api::voting-session.voting-session').findOne({ where: { id: sessionId } });
+      if (!sessionById || sessionById.status !== 'open') {
+        throw new ApplicationError('This voting session is not open for voting');
+      }
+    } else if (session.status !== 'open') {
+      throw new ApplicationError('This voting session is not open for voting');
+    }
+
+    // Check existing votes based ONLY on fingerprint to prevent blocking users on the same Wi-Fi
+    const existingVote = await strapi.db.query('api::vote.vote').findOne({
+      where: {
+        voting_session: sessionId,
+        fingerprint: fingerprint,
+      }
+    });
+
+    if (existingVote) {
+      throw new ApplicationError('You have already voted in this session.');
+    }
+  }
+};

--- a/src/api/vote/content-types/vote/schema.json
+++ b/src/api/vote/content-types/vote/schema.json
@@ -1,0 +1,40 @@
+{
+  "kind": "collectionType",
+  "collectionName": "votes",
+  "info": {
+    "singularName": "vote",
+    "pluralName": "votes",
+    "displayName": "Vote",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "ip_address": {
+      "type": "string"
+    },
+    "fingerprint": {
+      "type": "string",
+      "required": true
+    },
+    "voting_session": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::voting-session.voting-session",
+      "inversedBy": "votes"
+    },
+    "voting_option": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::voting-option.voting-option",
+      "inversedBy": "votes"
+    },
+    "user": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "plugin::users-permissions.user"
+    }
+  }
+}

--- a/src/api/vote/controllers/vote.ts
+++ b/src/api/vote/controllers/vote.ts
@@ -1,0 +1,22 @@
+/**
+ * vote controller
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::vote.vote', ({ strapi }) => ({
+  async create(ctx) {
+    // Inject IP address from the request into the body
+    const ip = ctx.request.ip;
+
+    if (ctx.request.body && ctx.request.body.data) {
+      ctx.request.body.data.ip_address = ip;
+    }
+
+    console.log(ctx.request.body)
+
+    // Call the default core action
+    const response = await super.create(ctx);
+    return response;
+  }
+}));

--- a/src/api/vote/routes/vote.ts
+++ b/src/api/vote/routes/vote.ts
@@ -1,0 +1,7 @@
+/**
+ * vote router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::vote.vote');

--- a/src/api/vote/services/vote.ts
+++ b/src/api/vote/services/vote.ts
@@ -1,0 +1,7 @@
+/**
+ * vote service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::vote.vote');

--- a/src/api/voting-option/content-types/voting-option/schema.json
+++ b/src/api/voting-option/content-types/voting-option/schema.json
@@ -1,0 +1,38 @@
+{
+  "kind": "collectionType",
+  "collectionName": "voting_options",
+  "info": {
+    "singularName": "voting-option",
+    "pluralName": "voting-options",
+    "displayName": "Voting Option",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "description": {
+      "type": "text"
+    },
+    "pitch_order": {
+      "type": "integer"
+    },
+    "voting_session": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::voting-session.voting-session",
+      "inversedBy": "voting_options"
+    },
+    "votes": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::vote.vote",
+      "mappedBy": "voting_option"
+    }
+  }
+}

--- a/src/api/voting-option/controllers/voting-option.ts
+++ b/src/api/voting-option/controllers/voting-option.ts
@@ -1,0 +1,7 @@
+/**
+ * voting-option controller
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::voting-option.voting-option');

--- a/src/api/voting-option/routes/voting-option.ts
+++ b/src/api/voting-option/routes/voting-option.ts
@@ -1,0 +1,7 @@
+/**
+ * voting-option router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::voting-option.voting-option');

--- a/src/api/voting-option/services/voting-option.ts
+++ b/src/api/voting-option/services/voting-option.ts
@@ -1,0 +1,7 @@
+/**
+ * voting-option service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::voting-option.voting-option');

--- a/src/api/voting-session/content-types/voting-session/schema.json
+++ b/src/api/voting-session/content-types/voting-session/schema.json
@@ -1,0 +1,52 @@
+{
+  "kind": "collectionType",
+  "collectionName": "voting_sessions",
+  "info": {
+    "singularName": "voting-session",
+    "pluralName": "voting-sessions",
+    "displayName": "Voting Session",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "description": {
+      "type": "text"
+    },
+    "event_id": {
+      "type": "string"
+    },
+    "status": {
+      "type": "enumeration",
+      "enum": [
+        "draft",
+        "open",
+        "closed"
+      ],
+      "default": "draft",
+      "required": true
+    },
+    "max_votes_per_user": {
+      "type": "integer",
+      "default": 1
+    },
+    "voting_options": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::voting-option.voting-option",
+      "mappedBy": "voting_session"
+    },
+    "votes": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::vote.vote",
+      "mappedBy": "voting_session"
+    }
+  }
+}

--- a/src/api/voting-session/controllers/voting-session.ts
+++ b/src/api/voting-session/controllers/voting-session.ts
@@ -1,0 +1,53 @@
+/**
+ * voting-session controller
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::voting-session.voting-session', ({ strapi }) => ({
+  async getResults(ctx) {
+    const { sessionId } = ctx.params;
+
+    // console.log(sessionId)
+
+    // Find all votes for the given session ID and populate the voting_option relation using the core service
+    const response = await strapi.service('api::vote.vote').find({
+      filters: {
+        voting_session: {
+          documentId: sessionId,
+        },
+      },
+      populate: ['voting_option', 'voting_session'],
+    });
+
+    // Extract results from the service response (which returns { results, pagination })
+    const votes = response?.results || response || [];
+
+    // console.log(votes)
+
+    const voteCounts: Record<string, number> = {};
+    const optionNames: Record<string, string> = {};
+
+    for (const vote of votes) {
+      if (vote.voting_option) {
+        const optionId = vote.voting_option.id;
+        const optionName = vote.voting_option.name;
+
+        optionNames[optionId] = optionName;
+        if (!voteCounts[optionId]) {
+          voteCounts[optionId] = 0;
+        }
+        voteCounts[optionId]++;
+      }
+    }
+
+    // Format the result to match the expected example JSON
+    // [{ "option": "Startup A", "votes": 32 }]
+    const result = Object.keys(voteCounts).map(optionId => ({
+      option: optionNames[optionId],
+      votes: voteCounts[optionId],
+    }));
+
+    return result.sort((a, b) => b.votes - a.votes);
+  }
+}));

--- a/src/api/voting-session/routes/custom-results.ts
+++ b/src/api/voting-session/routes/custom-results.ts
@@ -1,0 +1,12 @@
+export default {
+  routes: [
+    {
+      method: "GET",
+      path: "/voting/results/:sessionId",
+      handler: "voting-session.getResults",
+      config: {
+        auth: false,
+      },
+    },
+  ],
+};

--- a/src/api/voting-session/routes/voting-session.ts
+++ b/src/api/voting-session/routes/voting-session.ts
@@ -1,0 +1,7 @@
+/**
+ * voting-session router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::voting-session.voting-session');

--- a/src/api/voting-session/services/voting-session.ts
+++ b/src/api/voting-session/services/voting-session.ts
@@ -1,0 +1,7 @@
+/**
+ * voting-session service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::voting-session.voting-session');

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,72 @@ export default {
    * run jobs, or perform some special logic.
    */
   async bootstrap({ strapi }: { strapi: any }) {
+    // Grant public permissions for voting
+    try {
+      const publicRole = await strapi.db.query('plugin::users-permissions.role').findOne({
+        where: { type: 'public' },
+      });
+
+      if (publicRole) {
+        // Permissions to grant
+        const permissionsToGrant = [
+          'api::voting-session.voting-session.find',
+          'api::voting-session.voting-session.findOne',
+          'api::voting-session.voting-session.getResults',
+          'api::voting-option.voting-option.find',
+          'api::voting-option.voting-option.findOne',
+          'api::vote.vote.create',
+        ];
+
+        for (const action of permissionsToGrant) {
+          const existingPermission = await strapi.db.query('plugin::users-permissions.permission').findOne({
+            where: {
+              role: publicRole.id,
+              action: action,
+            },
+          });
+
+          if (!existingPermission) {
+            await strapi.db.query('plugin::users-permissions.permission').create({
+              data: {
+                role: publicRole.id,
+                action: action,
+              },
+            });
+            strapi.log.info(`Granted public permission: ${action}`);
+          }
+        }
+      }
+    } catch (err) {
+      strapi.log.error('Failed to bootstrap voting permissions: ' + err.message);
+    }
+
+    // Add indexes for Performance Considerations (session_id, option_id, fingerprint)
+    try {
+      const knex = strapi.db.connection;
+      const tableExists = await knex.schema.hasTable('votes');
+      if (tableExists) {
+        // Fingerprint index
+        await knex.schema.alterTable('votes', (table) => {
+          table.index(['fingerprint'], 'idx_vote_fingerprint').catch(() => {});
+        }).catch(() => {});
+        
+        // Relation indexes (Strapi might create these automatically, but we ensure them here)
+        // Note: Strapi usually names foreign keys as <relation_name>_id
+        await knex.schema.alterTable('votes', (table) => {
+          table.index(['voting_session_id'], 'idx_vote_session').catch(() => {});
+        }).catch(() => {});
+
+        await knex.schema.alterTable('votes', (table) => {
+          table.index(['voting_option_id'], 'idx_vote_option').catch(() => {});
+        }).catch(() => {});
+        
+        strapi.log.info('Voting performance indexes ensured');
+      }
+    } catch (err) {
+      strapi.log.warn('Could not define custom performance indexes, they might exist or table not ready: ' + err.message);
+    }
+
     // Set the reset password URL programmatically
     const pluginStore = strapi.store({
       type: "plugin",

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -813,6 +813,124 @@ export interface ApiTalkTalk extends Struct.CollectionTypeSchema {
   };
 }
 
+export interface ApiVoteVote extends Struct.CollectionTypeSchema {
+  collectionName: 'votes';
+  info: {
+    description: '';
+    displayName: 'Vote';
+    pluralName: 'votes';
+    singularName: 'vote';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    fingerprint: Schema.Attribute.String & Schema.Attribute.Required;
+    ip_address: Schema.Attribute.String;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<'oneToMany', 'api::vote.vote'> &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    user: Schema.Attribute.Relation<
+      'manyToOne',
+      'plugin::users-permissions.user'
+    >;
+    voting_option: Schema.Attribute.Relation<
+      'manyToOne',
+      'api::voting-option.voting-option'
+    >;
+    voting_session: Schema.Attribute.Relation<
+      'manyToOne',
+      'api::voting-session.voting-session'
+    >;
+  };
+}
+
+export interface ApiVotingOptionVotingOption
+  extends Struct.CollectionTypeSchema {
+  collectionName: 'voting_options';
+  info: {
+    description: '';
+    displayName: 'Voting Option';
+    pluralName: 'voting-options';
+    singularName: 'voting-option';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    description: Schema.Attribute.Text;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::voting-option.voting-option'
+    > &
+      Schema.Attribute.Private;
+    name: Schema.Attribute.String & Schema.Attribute.Required;
+    pitch_order: Schema.Attribute.Integer;
+    publishedAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    votes: Schema.Attribute.Relation<'oneToMany', 'api::vote.vote'>;
+    voting_session: Schema.Attribute.Relation<
+      'manyToOne',
+      'api::voting-session.voting-session'
+    >;
+  };
+}
+
+export interface ApiVotingSessionVotingSession
+  extends Struct.CollectionTypeSchema {
+  collectionName: 'voting_sessions';
+  info: {
+    description: '';
+    displayName: 'Voting Session';
+    pluralName: 'voting-sessions';
+    singularName: 'voting-session';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    description: Schema.Attribute.Text;
+    event_id: Schema.Attribute.String;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::voting-session.voting-session'
+    > &
+      Schema.Attribute.Private;
+    max_votes_per_user: Schema.Attribute.Integer &
+      Schema.Attribute.DefaultTo<1>;
+    publishedAt: Schema.Attribute.DateTime;
+    status: Schema.Attribute.Enumeration<['draft', 'open', 'closed']> &
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<'draft'>;
+    title: Schema.Attribute.String & Schema.Attribute.Required;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    votes: Schema.Attribute.Relation<'oneToMany', 'api::vote.vote'>;
+    voting_options: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::voting-option.voting-option'
+    >;
+  };
+}
+
 export interface PluginContentReleasesRelease
   extends Struct.CollectionTypeSchema {
   collectionName: 'strapi_releases';
@@ -1338,6 +1456,9 @@ declare module '@strapi/strapi' {
       'api::speaker.speaker': ApiSpeakerSpeaker;
       'api::tag.tag': ApiTagTag;
       'api::talk.talk': ApiTalkTalk;
+      'api::vote.vote': ApiVoteVote;
+      'api::voting-option.voting-option': ApiVotingOptionVotingOption;
+      'api::voting-session.voting-session': ApiVotingSessionVotingSession;
       'plugin::content-releases.release': PluginContentReleasesRelease;
       'plugin::content-releases.release-action': PluginContentReleasesReleaseAction;
       'plugin::i18n.locale': PluginI18NLocale;


### PR DESCRIPTION
# feat: implement voting system infrastructure and aggregation API

## 📝 Description
This Pull Request introduces the core backend infrastructure to support the new Voting System, allowing users to vote for startup options within specific sessions. It includes schema modeling, business rules for vote validation, and a custom API for result aggregations natively built into Strapi v5.

## ✨ Key Features & Changes
- **New Content Types:**
  - `voting-session`: Manages voting events with statuses (`draft`, `open`, `closed`).
  - `voting-option`: Represents the startup options linked to a specific session (includes logo, name, and pitch order).
  - `vote`: Stores incoming votes, relating back to sessions, options, and capturing user device information for auditing.

- **Voting Business Logic & Integrity:**
  - Implemented a [beforeCreate](cci:1://file:///Volumes/Extra/projects/8020/hub-community-backend/src/api/vote/content-types/vote/lifecycles.ts:4:2-59:3) lifecycle hook on the `vote` model to strictly prevent duplicate votes within the same session.
  - The validation utilizes `fingerprint` checking natively adapted to support Strapi v5 Document Service relational sets (`set`).
  - IP verification constraints were removed to gracefully handle scenarios where hundreds of users share the same NAT/Wi-Fi connection during live events, preventing unintended mass blocks.
  - Overridden the default `vote` creation controller to automatically extract and record the client's `ip_address` on the database level for further auditing.

- **Aggregation API:**
  - Added a custom REST endpoint `GET /api/voting/results/:sessionId` to provide real-time aggregation of votes mapped to their startup options.
  - Adapted the underlying controller to consume the `strapi.service` layer rather than simple direct `db.query`, scaling better within Strapi mechanics.

- **Bootstrapping & Performance:**
  - Configured [src/index.ts](cci:7://file:///Volumes/Extra/projects/8020/hub-community-backend/src/index.ts:0:0-0:0) to automatically assign read and create permissions for the `public` role to voting endpoints on application startup.
  - Dynamic index creation logic added to optimize heavy performance queries on attributes like `voting_session_id`, `voting_option_id`, and `fingerprint`.

## ✅ Testing Steps
1. Create a `voting-session` and multiple `voting-option` records. Be sure to set the session's status to `open`.
2. Perform a `POST /api/votes` request manually passing `fingerprint`, `voting_session`, and `voting_option`. Observe HTTP 201 behavior.
3. Submit the same request with the exact same fingerprint to see the duplicate vote prevention trigger HTTP 400 (`"You have already voted in this session."`).
4. Perform a `GET /api/voting/results/:sessionId` to witness real-time structured calculation responses mapping options to vote counts.
