### PR TITLE
create sw-form entity with public video upload support

### DIFF
--- a/config/middlewares.ts
+++ b/config/middlewares.ts
@@ -2,10 +2,24 @@ export default [
   'strapi::logger',
   'strapi::errors',
   'strapi::security',
-  'strapi::cors',
+  {
+    name: 'strapi::cors',
+    config: {
+      origin: '*',
+      headers: ['Content-Type', 'Authorization', 'Origin', 'Accept'],
+    },
+  },
   'strapi::poweredBy',
   'strapi::query',
-  'strapi::body',
+  {
+    name: 'strapi::body',
+    config: {
+      multipart: true,
+      formidable: {
+        maxFileSize: 250 * 1024 * 1024, // 250MB for video uploads
+      },
+    },
+  },
   'strapi::session',
   'strapi::favicon',
   'strapi::public',

--- a/src/api/sw-form/content-types/sw-form/schema.json
+++ b/src/api/sw-form/content-types/sw-form/schema.json
@@ -43,6 +43,9 @@
         "files",
         "videos"
       ]
+    },
+    "accepted_in": {
+      "type": "date"
     }
   }
 }

--- a/src/api/sw-form/content-types/sw-form/schema.json
+++ b/src/api/sw-form/content-types/sw-form/schema.json
@@ -1,0 +1,48 @@
+{
+  "kind": "collectionType",
+  "collectionName": "sw_forms",
+  "info": {
+    "singularName": "sw-form",
+    "pluralName": "sw-forms",
+    "displayName": "SW Form"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "cpf": {
+      "type": "string",
+      "required": true,
+      "unique": true
+    },
+    "date_of_birth": {
+      "type": "date",
+      "required": true
+    },
+    "whatsapp": {
+      "type": "string",
+      "required": true
+    },
+    "college": {
+      "type": "string"
+    },
+    "college_course": {
+      "type": "string"
+    },
+    "video": {
+      "type": "media",
+      "private": true,
+      "multiple": false,
+      "required": true,
+      "allowedTypes": [
+        "files",
+        "videos"
+      ]
+    }
+  }
+}

--- a/src/api/sw-form/controllers/sw-form.ts
+++ b/src/api/sw-form/controllers/sw-form.ts
@@ -1,0 +1,7 @@
+/**
+ * sw-form controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::sw-form.sw-form');

--- a/src/api/sw-form/routes/sw-form.ts
+++ b/src/api/sw-form/routes/sw-form.ts
@@ -1,0 +1,7 @@
+/**
+ * sw-form router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::sw-form.sw-form');

--- a/src/api/sw-form/services/sw-form.ts
+++ b/src/api/sw-form/services/sw-form.ts
@@ -1,0 +1,7 @@
+/**
+ * sw-form service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::sw-form.sw-form');

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,8 @@ export default {
           'api::voting-option.voting-option.find',
           'api::voting-option.voting-option.findOne',
           'api::vote.vote.create',
+          'api::sw-form.sw-form.create',
+          'plugin::upload.content-api.upload',
         ];
 
         for (const action of permissionsToGrant) {

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -796,6 +796,7 @@ export interface ApiSwFormSwForm extends Struct.CollectionTypeSchema {
     draftAndPublish: false;
   };
   attributes: {
+    accepted_in: Schema.Attribute.Date;
     college: Schema.Attribute.String;
     college_course: Schema.Attribute.String;
     cpf: Schema.Attribute.String &

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -785,6 +785,44 @@ export interface ApiSpeakerSpeaker extends Struct.CollectionTypeSchema {
   };
 }
 
+export interface ApiSwFormSwForm extends Struct.CollectionTypeSchema {
+  collectionName: 'sw_forms';
+  info: {
+    displayName: 'SW Form';
+    pluralName: 'sw-forms';
+    singularName: 'sw-form';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    college: Schema.Attribute.String;
+    college_course: Schema.Attribute.String;
+    cpf: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    date_of_birth: Schema.Attribute.Date & Schema.Attribute.Required;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::sw-form.sw-form'
+    > &
+      Schema.Attribute.Private;
+    name: Schema.Attribute.String & Schema.Attribute.Required;
+    publishedAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    video: Schema.Attribute.Media<'files' | 'videos'> &
+      Schema.Attribute.Required &
+      Schema.Attribute.Private;
+    whatsapp: Schema.Attribute.String & Schema.Attribute.Required;
+  };
+}
+
 export interface ApiTagTag extends Struct.CollectionTypeSchema {
   collectionName: 'tags';
   info: {
@@ -1492,6 +1530,7 @@ declare module '@strapi/strapi' {
       'api::participant.participant': ApiParticipantParticipant;
       'api::rate.rate': ApiRateRate;
       'api::speaker.speaker': ApiSpeakerSpeaker;
+      'api::sw-form.sw-form': ApiSwFormSwForm;
       'api::tag.tag': ApiTagTag;
       'api::talk.talk': ApiTalkTalk;
       'api::vote.vote': ApiVoteVote;


### PR DESCRIPTION
- Add sw-form collection type (name, cpf, date_of_birth, whatsapp, college, college_course, video)
- Configure video field as media type (files/videos), private, required
- Grant public permissions for sw-form create and file upload
- Configure body parser for 250MB multipart uploads
- Set CORS to allow all origins with explicit headers